### PR TITLE
Correction to language_info in kernel.py

### DIFF
--- a/ilua/kernel.py
+++ b/ilua/kernel.py
@@ -43,8 +43,8 @@ class ILuaKernel(KernelBase):
     implementation_version = ilua_version
     language = "lua"
     language_info = {
-        'name': 'Lua',
-        'mimetype': 'text/plain',
+        'name': 'lua',
+        'mimetype': 'text/x-lua',
         'file_extension': '.lua',
         'version': 'n/a'
     }


### PR DESCRIPTION
The syntax highlighting wasn't working. After some investigation, it appears that the `'name'` and the `'mimetype'` fields in `language_info` (in `kernel.py`, class `ILuaKernel`) needed modification (to `'lua'` and `'text/x-lua'`, respectively). The highlighting now works as expected.