### PR TITLE
Fixed the bug with incorrect variable name when importing `__version__`

### DIFF
--- a/ilua/__init__.py
+++ b/ilua/__init__.py
@@ -4,4 +4,4 @@
 # This file is part of ILua which is released under GPLv2.
 # See file LICENSE or go to https://www.gnu.org/licenses/gpl-2.0.txt
 # for full license details.
-from .version import version as __version__
+from .version import __version__

--- a/ilua/kernel.py
+++ b/ilua/kernel.py
@@ -29,7 +29,7 @@ from .kernelbase import KernelBase
 from .namedpipe import CoupleOPipes, get_pipe_path
 from .proto import InterpreterProtocol, OutputCapture
 from .inspector import Inspector
-from .version import version as ilua_version
+from .version import __version__ as ilua_version
 
 INTERPRETER_SCRIPT = os.path.join(os.path.dirname(__file__), "interp.lua")
 LUA_PATH_EXTRA = os.path.join(os.path.dirname(__file__), "?.lua")


### PR DESCRIPTION
Was introduced in c16f1cb0753b4e6fa75a5bae873c3d86db655a6f .