### PR TITLE
Allow redefining kernel help_links with ILUA_HELP_LINKS environment variable

### DIFF
--- a/ilua/kernel.py
+++ b/ilua/kernel.py
@@ -11,6 +11,7 @@ output capturing, frontend requests, and other
 stuff
 """
 
+import json
 import os
 import re
 
@@ -56,6 +57,10 @@ class ILuaKernel(KernelBase):
         {"text": "Lua Reference",
          "url": "https://www.lua.org/manual/"}
     ]
+
+    # Allow kernel definitions to override the help links
+    if "ILUA_HELP_LINKS" in os.environ:
+        help_links = json.loads(os.environ["ILUA_HELP_LINKS"])
 
     def __init__(self, *args, **kwargs):
         super(ILuaKernel, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The ILUA_HELP_LINKS variable can be set in kernel.json file like this:

    {
    	"argv":
    	[
    		"python",
    		"-m",
    		"ilua.app",
    		"-c",
    		"{connection_file}",
    		"-i",
    		"rpmlua"
    	],
    	"display_name": "RPM Lua",
    	"language": "lua",
    	"interrupt_mode": "message",
    	"env": {
    		"ILUA_HELP_LINKS": "[{\"text\": \"Lua in RPM\", \"url\": \"https://rpm-software-management.github.io/rpm/manual/lua.html\"}]"
    	}
    }

The nested json in json syntax is a bit hard to read,
but OTOH json works well for serializing a list of dictionaries to an environment variable.

Fixes https://github.com/guysv/ilua/issues/15